### PR TITLE
Notion MCP fixes: robust Status/Select support, query sort fix, debug info, docs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,6 +16,10 @@ GOOGLE_APPLICATION_CREDENTIALS=
 # Example: NOTION_MCP_TOKEN=secret_xxx
 NOTION_MCP_TOKEN=
 
+# Default Notion database ID used when not provided explicitly to tools
+# Example: NOTION_DATABASE_ID=2554cc35-4636-8145-aba9-c56e5b103977
+NOTION_DATABASE_ID=
+
 # Firecrawl MCP API key (for remote SSE endpoint or npx stdio)
 # Example: FIRECRAWL_API_KEY=fc-xxxxxxx
 FIRECRAWL_API_KEY=

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/cuddly-octo-telegram.iml
+++ b/.idea/cuddly-octo-telegram.iml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.12 (cuddly-octo-telegram)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="GOOGLE" />
+    <option name="myDocStringFormat" value="Google" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/docs/templates" />
+      </list>
+    </option>
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,70 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="DuplicatedCode" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <Languages>
+        <language minSize="156" name="Python" />
+      </Languages>
+    </inspection_tool>
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="HtmlUnknownAttribute" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="href" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+    <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="7">
+            <item index="0" class="java.lang.String" itemvalue="nobr" />
+            <item index="1" class="java.lang.String" itemvalue="noembed" />
+            <item index="2" class="java.lang.String" itemvalue="comment" />
+            <item index="3" class="java.lang.String" itemvalue="noscript" />
+            <item index="4" class="java.lang.String" itemvalue="embed" />
+            <item index="5" class="java.lang.String" itemvalue="script" />
+            <item index="6" class="java.lang.String" itemvalue="li" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+    <inspection_tool class="HtmlUnknownTarget" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E701" />
+          <option value="E741" />
+          <option value="E501" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8NamingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="N802" />
+          <option value="N806" />
+          <option value="N801" />
+          <option value="N803" />
+          <option value="N812" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyProtectedMemberInspection" enabled="true" level="INFORMATION" enabled_by_default="true" />
+    <inspection_tool class="PyRedeclarationInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyShadowingNamesInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="PartTwo.QDoubleSpinBox.UI.*" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="Stylelint" enabled="true" level="ERROR" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="42f13517:17d783b087a:-8000" />
+        <option name="version" value="8.13.2" />
+      </MTProjectMetadataState>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.12 (cuddly-octo-telegram)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12 (cuddly-octo-telegram)" project-jdk-type="Python SDK" />
+  <component name="PythonCompatibilityInspectionAdvertiser">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/cuddly-octo-telegram.iml" filepath="$PROJECT_DIR$/.idea/cuddly-octo-telegram.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/config/runconfig.yaml
+++ b/config/runconfig.yaml
@@ -51,6 +51,23 @@ agents:
       - After DRAFT, invoke POLISH with the draft.
       - After POLISH, invoke SEGMENT with the polished script.
       - Only after SEGMENT, produce the final response summarizing results and including deliverables.     
+  topic_verifier:
+    model: gemini-2.5-flash
+    name: topic_verifier
+    description: Verifies and selects eligible topics from Notion to kick off the pipeline.
+    instruction: |
+      You are the first stage of the pipeline. Interface with Notion to pull eligible rows where Status == "Not Started".
+      Use MCP tools to query a Notion database and return a shortlist of topics to process next.
+      
+      Contract:
+      - Call the local MCP tool `notion_query_eligible` with inputs {database_id, status_property: "Status", status_value: "Not Started", page_size: 5}.
+      - Select 1 topic to process. Include: page_id, title, and any relevant metadata (e.g., angle/stance if present).
+      - Optionally call `notion_update_status` to set Status = "In Progress" on the selected page.
+      - Output a compact JSON: {page_id, title, metadata}.
+      
+      Notes:
+      - If no eligible rows are found, return an empty decision with reason.
+      - Respect rate limits; avoid excessive calls.
   research_summarizer:
     model: gemini-2.5-flash
     name: research_summarizer

--- a/config/runconfig.yaml
+++ b/config/runconfig.yaml
@@ -56,18 +56,13 @@ agents:
     name: topic_verifier
     description: Verifies and selects eligible topics from Notion to kick off the pipeline.
     instruction: |
-      You are the first stage of the pipeline. Interface with Notion to pull eligible rows where Status == "Not Started".
-      Use MCP tools to query a Notion database and return a shortlist of topics to process next.
-      
-      Contract:
-      - Call the local MCP tool `notion_query_eligible` with inputs {database_id, status_property: "Status", status_value: "Not Started", page_size: 5}.
-      - Select 1 topic to process. Include: page_id, title, and any relevant metadata (e.g., angle/stance if present).
-      - Optionally call `notion_update_status` to set Status = "In Progress" on the selected page.
-      - Output a compact JSON: {page_id, title, metadata}.
-      
-      Notes:
-      - If no eligible rows are found, return an empty decision with reason.
-      - Respect rate limits; avoid excessive calls.
+      You interface with a Notion database that tracks topics via a Status lifecycle.
+      Use the local MCP tools to:
+      - Query eligible rows: call `notion_query_eligible` (defaults to Status = "Not Started"). If your Notion property is a Status-type (not Select), pass `property_type: "status"`.
+      - If a row is found, set it to "In Progress" with `notion_update_status` (also pass `property_type: "status"` if applicable).
+      - Output a compact JSON: {page_id, title, metadata}. If none found, explain why.
+      The Status lifecycle is: Not Started -> In Progress -> Done.
+      If `database_id` is omitted, the tool will read NOTION_DATABASE_ID from env.
   research_summarizer:
     model: gemini-2.5-flash
     name: research_summarizer
@@ -106,6 +101,10 @@ agents:
     description: Splits the polished script into ~60-second segments with sharp hooks for Shorts/Reels/TikTok.
     instruction: |
       Identify 4-8 self-contained beats. For each: craft a hook (≤12 words), 45-55 seconds of body copy, and a punchy sign-off or cliffhanger. Return {title, hook, est_duration, segment_text, on-screen cue suggestions}.
+      
+      End-of-pipeline Notion update:
+      - If you received pipeline context containing a Notion `page_id` from `topic_verifier`, call the local MCP tool `notion_update_status` with {page_id, status_property: "Status", status_value: "Done", property_type: "status"} to mark the item complete when the property is a Notion Status-type.
+      - If `page_id` is unavailable, proceed without updating Notion.
 
 mcp:
   enabled: true

--- a/docs/features/notion_integration.md
+++ b/docs/features/notion_integration.md
@@ -1,0 +1,52 @@
+# Feature: Notion Integration (topic_verifier)
+
+This feature adds a Notion-driven intake stage to the ADK pipeline, making a Notion database the single source of truth for topic lifecycle.
+
+- Pipeline Stage: `topic_verifier` (pre-stage before research)
+- Tools: Local MCP Notion tools in `src/tools/local_mcp_server.py`
+- Config: New agent block in `config/runconfig.yaml`
+- Tests: Wiring and tool tests with mocked HTTP
+
+## Summary
+- Goal: Select eligible topics from a Notion database to kick off the pipeline.
+- Scope: Pipeline stage + local MCP tool integration + tests + docs.
+- Deliverables:
+  - New agent `topic_verifier` wired into fixed order.
+  - MCP tools: `notion_query_eligible`, `notion_update_status`.
+  - Tests for wiring and tools.
+
+## Details
+
+### Stage Behavior (`topic_verifier`)
+- Queries Notion for rows with `Status = "Not Started"`.
+- Selects one row to process and may set it to `In Progress`.
+- Outputs a compact JSON `{page_id, title, metadata}` for downstream stages.
+
+### MCP Tools (local stdio)
+Defined in `src/tools/local_mcp_server.py` using `FastMCP`:
+- `notion_query_eligible(database_id, status_property="Status", status_value="Not Started", page_size=5)`
+  - Calls `POST /v1/databases/{database_id}/query`
+  - Returns minimal page list: `[{page_id, title, properties}]`.
+- `notion_update_status(page_id, status_property="Status", status_value="In Progress")`
+  - Calls `PATCH /v1/pages/{page_id}`
+  - Updates a select property to a new value.
+
+Environment variable required: `NOTION_MCP_TOKEN`.
+
+### Config
+Add an agent block under `agents.topic_verifier` in `config/runconfig.yaml` (already added).
+Coordinator fixed order updated in `src/orchestration/coordinator.py` to include `topic_verifier` and remain backward compatible with `topic_clarifier`.
+
+### Testing
+- `tests/test_topic_verifier_wiring.py`: asserts coordinator builds Sequential pipeline with `topic_verifier`.
+- `tests/test_notion_tools.py`: unit tests Notion tools with mocked `httpx.Client`.
+
+## Usage Notes
+- Ensure `.env` has `NOTION_MCP_TOKEN`.
+- `config/runconfig.yaml → mcp.enabled: true` and `connection.type: stdio` are already configured.
+
+## Backout Plan
+- Remove the `topic_verifier` block from YAML.
+- Revert `coordinator.py` fixed order changes.
+- Remove Notion MCP tools.
+- Skip/remove tests.

--- a/docs/features/notion_integration.md
+++ b/docs/features/notion_integration.md
@@ -21,21 +21,30 @@ This feature adds a Notion-driven intake stage to the ADK pipeline, making a Not
 - Queries Notion for rows with `Status = "Not Started"`.
 - Selects one row to process and may set it to `In Progress`.
 - Outputs a compact JSON `{page_id, title, metadata}` for downstream stages.
+ - Status lifecycle: `Not Started` → `In Progress` → `Done`.
 
 ### MCP Tools (local stdio)
 Defined in `src/tools/local_mcp_server.py` using `FastMCP`:
-- `notion_query_eligible(database_id, status_property="Status", status_value="Not Started", page_size=5)`
+- `notion_query_eligible(database_id=None, status_property="Status", status_value="Not Started", property_type="select", page_size=5)`
   - Calls `POST /v1/databases/{database_id}/query`
   - Returns minimal page list: `[{page_id, title, properties}]`.
+  - If `database_id` is omitted, reads `NOTION_DATABASE_ID` from the environment.
+  - property_type can be `select` (default) or `status` (Notion Status-type). The tool internally retries with the other type and common capitalization variants if the first attempt fails or yields zero results.
 - `notion_update_status(page_id, status_property="Status", status_value="In Progress")`
   - Calls `PATCH /v1/pages/{page_id}`
   - Updates a select property to a new value.
+  - Accepts `property_type` (default `select`). Internally retries with the other type and capitalization variants on failure.
 
-Environment variable required: `NOTION_MCP_TOKEN`.
+Environment variables required:
+- `NOTION_MCP_TOKEN` — Notion API token
+- `NOTION_DATABASE_ID` — default database used when `database_id` arg is omitted
 
 ### Config
 Add an agent block under `agents.topic_verifier` in `config/runconfig.yaml` (already added).
 Coordinator fixed order updated in `src/orchestration/coordinator.py` to include `topic_verifier` and remain backward compatible with `topic_clarifier`.
+
+End-of-pipeline behavior:
+- The `social_segmenter` instruction includes an explicit step to call `notion_update_status` with `status_value: "Done"` when a `page_id` is available from `topic_verifier`.
 
 ### Testing
 - `tests/test_topic_verifier_wiring.py`: asserts coordinator builds Sequential pipeline with `topic_verifier`.

--- a/src/orchestration/coordinator.py
+++ b/src/orchestration/coordinator.py
@@ -59,6 +59,9 @@ def build_coordinator(
     else:
         # Pipeline-aware wiring path
         pipeline_order = [
+            # New first stage: topic_verifier (replaces legacy topic_clarifier)
+            # Keep legacy 'topic_clarifier' support by also wiring it if present
+            "topic_verifier",
             "topic_clarifier",
             "research_summarizer",
             "outline_organizer",
@@ -77,7 +80,8 @@ def build_coordinator(
                 tools_for_agent: List[object] = []
                 if shared_tools:
                     tools_for_agent.extend(shared_tools)
-                if key == "topic_clarifier" and topic_tools:
+                # Attach topic_tools to the topic intake stage (new: topic_verifier; legacy: topic_clarifier)
+                if key in ("topic_verifier", "topic_clarifier") and topic_tools:
                     tools_for_agent.extend(topic_tools)
                 sub_agents.append(_build_llm_agent_from_cfg(agent_cfg, extra_tools=tools_for_agent))
                 used_keys.add(key)
@@ -90,7 +94,8 @@ def build_coordinator(
             if not isinstance(agent_cfg, dict):
                 continue
             tools_for_agent = list(shared_tools or [])
-            if key == "topic_clarifier" and topic_tools:
+            # Ensure topic_tools also attach if the only topic stage is present outside fixed ordering
+            if key in ("topic_verifier", "topic_clarifier") and topic_tools:
                 tools_for_agent.extend(topic_tools)
             sub_agents.append(_build_llm_agent_from_cfg(agent_cfg, extra_tools=tools_for_agent))
             used_keys.add(key)

--- a/tests/test_notion_tools.py
+++ b/tests/test_notion_tools.py
@@ -1,0 +1,109 @@
+import os
+from typing import Any, Dict
+
+import pytest
+
+from src.tools.local_mcp_server import notion_query_eligible, notion_update_status
+
+
+class _MockResp:
+    def __init__(self, status_code: int, body: Dict[str, Any]):
+        self.status_code = status_code
+        self._body = body
+        self.text = "{\"mock\":true}"
+
+    def json(self) -> Dict[str, Any]:
+        return self._body
+
+
+class _MockClientQuery:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url: str, headers: Dict[str, str], json: Dict[str, Any]):
+        assert url.startswith("https://api.notion.com/v1/databases/") and url.endswith("/query")
+        assert headers.get("Authorization", "").startswith("Bearer ")
+        # Return one fake row shaped like Notion
+        return _MockResp(
+            200,
+            {
+                "results": [
+                    {
+                        "id": "page_123",
+                        "properties": {
+                            "Name": {
+                                "id": "title",
+                                "type": "title",
+                                "title": [
+                                    {"type": "text", "text": {"content": "Test Topic"}, "plain_text": "Test Topic"}
+                                ],
+                            },
+                            "Status": {"id": "status", "type": "select", "select": {"name": "Not Started"}},
+                        },
+                    }
+                ]
+            },
+        )
+
+
+class _MockClientPatch:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def patch(self, url: str, headers: Dict[str, str], json: Dict[str, Any]):
+        assert url.startswith("https://api.notion.com/v1/pages/")
+        assert headers.get("Authorization", "").startswith("Bearer ")
+        # Echo success
+        return _MockResp(200, {"object": "page", "id": url.split("/")[-1]})
+
+
+def test_notion_query_eligible_success(monkeypatch):
+    # Ensure token set
+    monkeypatch.setenv("NOTION_MCP_TOKEN", "notion-token")
+
+    # Patch httpx.Client to our mock
+    import httpx
+
+    monkeypatch.setattr(httpx, "Client", _MockClientQuery)
+
+    out = notion_query_eligible(database_id="db_abc", status_property="Status", status_value="Not Started", page_size=3)
+
+    assert out["success"] is True
+    assert out["status"] == 200
+    assert out["count"] == 1
+    assert out["results"][0]["title"] == "Test Topic"
+
+
+def test_notion_update_status_success(monkeypatch):
+    monkeypatch.setenv("NOTION_MCP_TOKEN", "notion-token")
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "Client", _MockClientPatch)
+
+    out = notion_update_status(page_id="page_123", status_property="Status", status_value="In Progress")
+    assert out["success"] is True
+    assert out["status"] == 200
+
+
+def test_notion_tools_missing_token(monkeypatch):
+    # Ensure token missing
+    monkeypatch.delenv("NOTION_MCP_TOKEN", raising=False)
+
+    out1 = notion_query_eligible(database_id="db_abc")
+    out2 = notion_update_status(page_id="page_123")
+
+    assert out1["success"] is False and "error" in out1
+    assert out2["success"] is False and "error" in out2

--- a/tests/test_notion_tools.py
+++ b/tests/test_notion_tools.py
@@ -107,3 +107,18 @@ def test_notion_tools_missing_token(monkeypatch):
 
     assert out1["success"] is False and "error" in out1
     assert out2["success"] is False and "error" in out2
+
+
+def test_notion_query_eligible_env_database_id(monkeypatch):
+    # Provide token and default database ID in env
+    monkeypatch.setenv("NOTION_MCP_TOKEN", "notion-token")
+    monkeypatch.setenv("NOTION_DATABASE_ID", "db_from_env")
+
+    # Patch httpx.Client to query mock
+    import httpx
+    monkeypatch.setattr(httpx, "Client", _MockClientQuery)
+
+    # Call without database_id argument; tool should read from env
+    out = notion_query_eligible(status_property="Status", status_value="Not Started", page_size=2)
+    assert out["success"] is True
+    assert out["count"] == 1

--- a/tests/test_topic_verifier_wiring.py
+++ b/tests/test_topic_verifier_wiring.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import pytest
+
+# Ensure project root on sys.path
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+try:
+    from google.adk.agents import SequentialAgent  # type: ignore
+except Exception:
+    pytest.skip("google-adk not installed; skipping wiring test", allow_module_level=True)
+
+from src.orchestration.coordinator import build_coordinator
+
+
+def test_build_with_topic_verifier_stage():
+    cfg = {
+        "coordinator": {"name": "coordinator"},
+        "topic_verifier": {
+            "name": "topic_verifier",
+            "model": "gemini-2.5-flash",
+            "instruction": "verify topics from notion",
+        },
+        # Add a second stage so SequentialAgent has >1 sub-agent
+        "research_summarizer": {
+            "name": "research_summarizer",
+            "model": "gemini-2.5-flash",
+            "instruction": "summarize research",
+        },
+    }
+
+    # No special tools required for this smoke test; ensure build doesn't require concrete tool objects
+    agent = build_coordinator(cfg, shared_tools=[], topic_tools=[])
+    assert isinstance(agent, SequentialAgent)
+    assert agent.name == "coordinator"


### PR DESCRIPTION
## Summary
This PR hardens the Notion MCP integration used by the `topic_verifier` stage and end-of-pipeline updates. It addresses 400 errors and schema mismatches by adding robust fallbacks and better guidance.

## Changes
- src/tools/local_mcp_server.py
  - Fix NameError in `notion_query_eligible()` return block
  - Correct Notion database query sort to use timestamp-based sort (Notion rejects `property: last_edited_time`)
  - Add robust fallback between Notion property types: `select` <-> `status`
  - Try common capitalization variants for status values (e.g., `Not started`, `Not Started`, `In Progress`, `Done`)
  - Include minimal debug info when the Notion request fails or returns 0 results
- config/runconfig.yaml
  - Update `topic_verifier` and `social_segmenter` instructions to pass `property_type: "status"` when the DB uses a Status-type property
- docs/features/notion_integration.md
  - Document `property_type` parameter and internal fallbacks
  - Clarify environment variable fallback (`NOTION_DATABASE_ID`)
- .env.sample
  - Add sample for `NOTION_DATABASE_ID`
- tests/test_notion_tools.py
  - Ensure env fallback test and updated tool behavior remain green

## Verification
- All tests pass locally: `11 passed`
- Manual run of the pipeline successfully:
  - Queried Notion and found eligible item(s) with `Status = Not started`
  - Advanced pipeline to produce final segmented outputs

## How to test
1. Set env vars:
   - `NOTION_MCP_TOKEN`
   - `NOTION_DATABASE_ID` (optional if provided via tool args)
2. Ensure your Notion DB has a `Status` column (Select or Status-type) with options:
   - `Not Started` / `Not started` (either is okay)
   - `In Progress` / `In progress`
   - `Done`
3. Run:
```bash
uv run python -m src.app \
  --task "Start pipeline; use Notion topic intake if available." \
  --auto-continue \
  --log-level INFO
```

## Docs
Full feature documentation and troubleshooting tips:
- docs/features/notion_integration.md

## Follow-ups (optional)
- Consider an atomic tool `notion_claim_next_topic()` to query + set `In Progress` in one call for even stronger reliability.
